### PR TITLE
Update netcdf4 to 1.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "1.2.3" %}
+
 package:
     name: netcdf4
-    version: 1.2.2
+    version: {{ version }}
 
 source:
-    fn: netCDF4-1.2.2.tar.gz
-    url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-1.2.2.tar.gz
-    md5: c8a80cb2bbfaae2faaff7d1d699b4b61
+    fn: netCDF4-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-{{ version }}.tar.gz
+    md5: 937b2acdbaff5c2a2b396979337cdc90
 
 build:
     number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
     fn: netCDF4-{{ version }}.tar.gz
     url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-{{ version }}.tar.gz
     md5: 937b2acdbaff5c2a2b396979337cdc90
+    patches:
+        - setup_cfg.patch  # [win]
 
 build:
     number: 0

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,7 +1,7 @@
 import netCDF4
 
 # OPeNDAP.
-url = 'http://omgsrv1.meas.ncsu.edu:8080/thredds/dodsC/fmrc/sabgom/SABGOM_Forecast_Model_Run_Collection_best.ncd'
+url = 'http://geoport-dev.whoi.edu/thredds/dodsC/estofs/atlantic'
 nc = netCDF4.Dataset(url)
 
 # Compiled with cython.

--- a/recipe/setup_cfg.patch
+++ b/recipe/setup_cfg.patch
@@ -1,0 +1,34 @@
+--- setup.py	2016-03-10 17:14:11.000000000 -0300
++++ setup.py	2016-03-11 09:52:55.604427285 -0300
+@@ -241,14 +241,19 @@
+ else:
+     retcode = 1
+ 
+-if not retcode:
++try:
++    HAS_PKG_CONFIG = subprocess.call(['pkg-config','--libs', 'hdf5'], stdout=subprocess.PIPE) == 0
++except OSError:
++    HAS_PKG_CONFIG = False
++
++if not retcode: # Try nc-config.
+     sys.stdout.write('using nc-config ...\n')
+     dep=subprocess.Popen([ncconfig,'--libs'],stdout=subprocess.PIPE).communicate()[0]
+     libs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-l' ]
+     lib_dirs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-L' ]
+     dep=subprocess.Popen([ncconfig,'--cflags'],stdout=subprocess.PIPE).communicate()[0]
+     inc_dirs = [str(i[2:].decode()) for i in dep.split() if i[0:2].decode() == '-I']
+-elif subprocess.call(['pkg-config','--libs', 'hdf5'],stdout=subprocess.PIPE) == 0:
++elif HAS_PKG_CONFIG: # Try pkg-config.
+     sys.stdout.write('using pkg-config ...\n')
+     dep=subprocess.Popen(['pkg-config','--libs','netcdf'],stdout=subprocess.PIPE).communicate()[0]
+     libs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-l' ]
+@@ -260,8 +265,7 @@
+     lib_dirs.extend([str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-L' ])
+     dep=subprocess.Popen(['pkg-config','--cflags', 'hdf5'],stdout=subprocess.PIPE).communicate()[0]
+     inc_dirs.extend([str(i[2:].decode()) for i in dep.split() if i[0:2].decode() == '-I'])
+-
+-# if nc-config and pkg-config both didn't work (it won't on windows), fall back on brute force method
++# If nc-config and pkg-config both didn't work (it won't on Windows), fall back on brute force method.
+ else:
+     dirstosearch =  [os.path.expanduser('~'),'/usr/local','/sw','/opt','/opt/local', '/usr']
+ 


### PR DESCRIPTION
```
 version 1.2.3 (tag v1.2.3rel)
==============================
 * try to avoid writing NC_STRING attributes if possible, by
   trying to convert unicode strings to ascii and write as NC_CHAR (issue
   #529).  This preserves compatibility with clients (like Matlab) that
   can't deal with NC_STRING attributes. A 'setncattr_string' method
   was added for Dataset and Variable to that users can force attributes
   to be written as NC_STRING if necessary.
 * fix failing tests with numpy 1.11 (issues #521 and #522).
 * fix indentation bug in nc4tonc3 utility (issue #519).
 * add the capability in setup.py to use pkg-config instead of
   nc-config (pull request #518).
 * make sure slices which return scalar masked arrays
   are consistent with numpy.ma (issue #515).
 * add test/tst_cdf5.py and test/tst_filepath.py (to test new
   NETCDF3_64BIT_DATA format and filepath Dataset method).
 * expose netcdftime.__version__ (issue #504).
 * fix potential memory leak in Dataset.filepath in attempt to fix
   mysterious segfaults on CentOS6 (issue #506). Segfaults  
   can apparently still occur on systems like CentOS6 with old versions of glibc.
```
