### PR TITLE
fix #4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 24fc0101c7c441709c230e76af611d53
 
 build:
-    number: 0
+    number: 1
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
         - nc4tonc3 = netCDF4.utils:nc4tonc3


### PR DESCRIPTION
Googling for "malformed mach-o image: load command length (0) too small" lead to solutions like: Re-build it :unamused: 

Let's see if that solves it here.
