### PR TITLE
Updated to 1.2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
     - secure: "k159DG8FFRefUb8gRkRUBAQwDI5LbKQ9aaBCPkz2HWSmCbzkwiOGh6hBpAVzmnHYKcz6BS08IH+9OWwEkhrUccZU6t4HyA7Tw1kJ6fNB3Ca/ZvtKdjSvHRnNX8mVQSJUX7Cmov3A4oFXshc2JEjlz/uhdP0KqTqtWC+mMaXT2N1Sfb1KenF3Bhs4a8x27QFkVK5UeUv1kxJxY1nUBA5EVOXOEu92xsrEhqwhQsHy0vsKMRaEaT+AB7WWRwzEDkRCoXJAM65pNmayXthpOD7WFCdRNtK0z+2BYijAq7iTC70mvfnUQexqo1pG0SnGz9bRUfKUC0NxNzRQIqWPi2Lt036R0PtdX1TX4r/uoho7St8lm37xr1W0MKmAntW1J+rC00acrm0N3gBCqNz0u8Oa0sEd97NPnazEevv/Jd7swOXHLgGtt/6GCd9PjfxVBS5r/XCdbvhtXnBiQf0oNses0CIg9f4VyOAer5R7FpcdwicUIUMz+g1u2sZ9EtA0RuH59vV1iTLxb2WOUJ+xNjYP/JPFBAIAsXDOqdhXzBymf7CPEtgmelK1RcoEQQfEJvJ2F7s/qr7JGCSTNuMvYvD1ucxC5iQS7Pb5U76NZFvwCzxRp/8SaFo0gp1vO8InHn3d96pWJeayp1oCh11mBgehtuD/GYhJE8QoBiXQSanl+24="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.3.1" %}
+{% set version = "1.2.4" %}
 
 package:
     name: netcdf4
@@ -7,10 +7,10 @@ package:
 source:
     fn: netCDF4-{{ version }}.tar.gz
     url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-{{ version }}.tar.gz
-    md5: 24fc0101c7c441709c230e76af611d53
+    md5: fb8083a17644bd559887b026fddd18a8
 
 build:
-    number: 2
+    number: 0
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
         - nc4tonc3 = netCDF4.utils:nc4tonc3


### PR DESCRIPTION
```
 version 1.2.4 (tag v1.2.4rel)
==============================
 * Fix for issue #554.  It is now ensured that data is in native endian
   byte order before passing to netcdf-c library.  Data read from variable
   with non-native byte order is also byte-swapped, so that dtype remains
   consistent with netcdf variable.  Behavior now consistent with h5py.
 * raise warning for HDF5 1.10.x (issue #549), since backwards 
   incompatible files may be created.
 * raise AttributeError instead of RuntimeError when attribute operation
   fails.  raise IOError instead of RuntimeError when nc_create or 
   nc_open fails (issue #546).
 * Use NamedTemporaryFile instead of deprecated mktemp in tests
   (pull request #543). 
 * add AppVeyor automated windows tests (pull request #540).
```
