### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
         - ncinfo -h
         - nc4tonc3 -h
         - nc3tonc4 -h
+        - conda inspect linkages -n _test netcdf4  # [linux]
 
 about:
     home: http://github.com/Unidata/netcdf4-python


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.
