### PR TITLE
Update to 1.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,13 @@ install:
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
 
+      # install conda-build 2.x to build with a long prefix
+      conda install --yes --quiet conda-build=2
+      conda info
+
 script:
   - conda build ./recipe
 
   - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  # inspect the prefix lengths of the built packages
+  - conda inspect prefix-lengths /Users/travis/miniconda3/conda-bld/osx-64/*.tar.bz2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -115,6 +115,10 @@ install:
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
+    - cmd: # install conda-build 2.x to build with a long prefix
+    - cmd: conda install --yes --quiet conda-build=2
+    - cmd: conda info
+
 # Skip .NET project specific build phase.
 build: off
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,10 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# install conda-build 2.x to build a long prefix
+conda install --yes --quiet conda-build=2
+conda info
+
 # Embarking on 6 case(s).
     set -x
     export CONDA_NPY=110
@@ -83,4 +87,7 @@ source run_conda_forge_build_setup
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+# inspect the prefix lengths of the built packages
+conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 
 package:
   name: netcdf4
@@ -7,7 +7,7 @@ package:
 source:
   fn: netCDF4-{{ version }}.tar.gz
   url: https://github.com/Unidata/netcdf4-python/archive/v{{ version }}rel.tar.gz
-  sha256: 1d98b22bcfcd9f728ce7220587ebe97bcc53ebbeabfe9983cfa421168363991e
+  sha256: c85321110ca979e81852705c0cf9fc659cd2b7233d6de67e26905833dcce1f45
 
 build:
   number: 0
@@ -39,8 +39,8 @@ test:
     - ncinfo -h
     - nc4tonc3 -h
     - nc3tonc4 -h
-    #- conda inspect linkages -p $PREFIX netcdf4  # [not win]
-    #- conda inspect objects -p $PREFIX netcdf4  # [osx]
+    - conda inspect linkages -p $PREFIX netcdf4  # [not win]
+    - conda inspect objects -p $PREFIX netcdf4  # [osx]
 
 about:
   home: http://github.com/Unidata/netcdf4-python


### PR DESCRIPTION
```
 version 1.2.6 (tag v1.2.6rel)
==============================
 * fix some test failures on big endian PPC64 that were due to 
   errors in byte-swapping logic. Also fixed bug in enum
   code exposed on PPC64 (issue #608).
 * remove support for python 2.6 (it probably still will work for a while
   though).
 * Sometimes checking that data being assigned to a variable has
   an 'ndim' attribute is not sufficient, instead check to see that
   the object supports the buffer interface (issue #613).
 * make get_variables_by_attributes work in MFDataset (issue #610)
   The hack is also applied for set_auto_maskandscale, set_auto_scale,
   set_automask, so these don't have to be duplicated in MFDataset (pull
   request #571).
```