### PR TITLE
update 1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 package:
   name: netcdf4
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/n/netCDF4/netCDF4-{{ version }}.tar.gz
-  sha256: 1982372aeacc6b36054d90d8cb54ee9506b66b6f44d5cff10e2ffb162aad5476
+  sha256: 570ea59992aa6d98a9b672c71161d11ba5683f787da53446086077470a869957
 
 build:
   number: 0


### PR DESCRIPTION
```
 version 1.3.1 (tag v1.3.1rel)
=============================
 * add parallel IO capabilities.  netcdf-c and hdf5 must be compiled with MPI
   support, and mpi4py must be installed.  To open a file for parallel access,
   use `parallel=True` in `Dataset.__init__` and optionally pass the mpi4py Comm instance
   using the `comm` kwarg and the mpi4py Info instance using the `info` kwarg.
   IO can be toggled between collective and independent using `Variable.set_collective`.
   See `examples/mpi_example.py`. Issue #717, pull request #716.
   Minimum cython dependency bumped from 0.19 to 0.21.
 * Add optional `MFTime` calendar overload to use across all files, for example,
   `'standard'` or `'gregorian'`. If `None` (the default), check that the calendar
   attribute is present on each variable and values are unique across files raising
   a `ValueError` otherwise.
 * Allow _FillValue to be set for vlen string variables (issue #730).
```