### PR TITLE
build with libnetcdf 4.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 570ea59992aa6d98a9b672c71161d11ba5683f787da53446086077470a869957
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3
@@ -24,7 +24,8 @@ requirements:
     - numpy 1.11.*  # [win and py36]
     - cython >=0.19
     - hdf5 1.10.1
-    - libnetcdf 4.4.*
+    - libnetcdf 4.4.*  # [win and py2k]
+    - libnetcdf 4.5.*  # [not (win and py2k)]
   run:
     - python
     - setuptools
@@ -32,7 +33,8 @@ requirements:
     - numpy >=1.9  # [win and py35]
     - numpy >=1.11  # [win and py36]
     - hdf5 1.10.1
-    - libnetcdf 4.4.*
+    - libnetcdf 4.4.*  # [win and py2k]
+    - libnetcdf 4.5.*  # [not (win and py2k)]
 
 test:
   imports:


### PR DESCRIPTION
Just a test for now. I don't really want to add the pre-processor selector everywhere we pin `libnetcdf`.