### PR TITLE
Rebuild netCDF4 after bug fix in libnetcdf build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,3 +56,4 @@ extra:
     - ocefpaf
     - pelson
     - dopplershift
+    - xylar

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d4fc65b98e348c39d082ab6b4b7f6d636b1b4e63bec016e5bca189fee5d46403
 
 build:
-  number: 2
+  number: 3
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3


### PR DESCRIPTION
The fix to libnetcdf should make nc-config produce a correct path,
which is expected to change the build of netCDF4.  In particular,
netCDF4 is expected to notice CDF5 support with this fix.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

closes #67 