### PR TITLE
Rebuild with latest libnetcdf build and hdf5 1.10.2

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -6,15 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -6,15 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -6,15 +6,11 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 macos_machine:
@@ -17,8 +15,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 macos_machine:
@@ -17,8 +15,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -6,8 +6,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 macos_machine:
@@ -17,8 +15,6 @@ macos_min_version:
 numpy:
 - '1.9'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/win_c_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008python2.7.yaml
@@ -4,15 +4,11 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -4,15 +4,11 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -4,15 +4,11 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-hdf5:
-- 1.10.3
 libnetcdf:
 - '4.6'
 numpy:
 - '1.11'
 pin_run_as_build:
-  hdf5:
-    max_pin: x.x.x
   libnetcdf:
     max_pin: x.x
   python:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Summary: Provides an object-oriented python interface to the netCDF version 4 li
 Current build status
 ====================
 
-[![Linux](https://img.shields.io/circleci/project/github/conda-forge/netcdf4-feedstock/master.svg?label=Linux)](https://circleci.com/gh/conda-forge/netcdf4-feedstock)
-[![OSX](https://img.shields.io/travis/conda-forge/netcdf4-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/netcdf4-feedstock)
-[![Windows](https://img.shields.io/appveyor/ci/conda-forge/netcdf4-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/netcdf4-feedstock/branch/master)
+[![Linux](https://img.shields.io/circleci/project/github/conda-forge/build_with_hdf5_1.10.2-feedstock/master.svg?label=Linux)](https://circleci.com/gh/conda-forge/build_with_hdf5_1.10.2-feedstock)
+[![OSX](https://img.shields.io/travis/conda-forge/build_with_hdf5_1.10.2-feedstock/master.svg?label=macOS)](https://travis-ci.org/conda-forge/build_with_hdf5_1.10.2-feedstock)
+[![Windows](https://img.shields.io/appveyor/ci/conda-forge/build_with_hdf5_1.10.2-feedstock/master.svg?label=Windows)](https://ci.appveyor.com/project/conda-forge/build-with-hdf5-1-10-2-feedstock/branch/master)
 
 Current release info
 ====================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d4fc65b98e348c39d082ab6b4b7f6d636b1b4e63bec016e5bca189fee5d46403
 
 build:
-  number: 3
+  number: 200
   entry_points:
     - ncinfo = netCDF4.utils:ncinfo
     - nc4tonc3 = netCDF4.utils:nc4tonc3
@@ -24,14 +24,14 @@ requirements:
     - numpy
     - cython >=0.19
     - cftime >=1.0.1
-    - hdf5
+    - hdf5 1.10.2
     - libnetcdf
   run:
     - python
     - setuptools
     - {{ pin_compatible('numpy') }}
     - cftime
-    - hdf5
+    - hdf5 1.10.2
     - libnetcdf
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

A recent fix to the libnetcdf build (https://github.com/conda-forge/libnetcdf-feedstock/pull/59) corrected the paths displayed by `nc-config` and allowed `netcdf4` to recognize cdf-5 format files once again.  #68 brought in this fix along with `hdf5` 1.10.3.  However, many conda-forge packages (notably `h5py`) are not yet built with `hdf5` 1.10.3. So it will be useful to have a build with the `nc-config` fix *and* with `hdf5` 1.10.2.