### PR TITLE
MNT: Try removing some library pins

### DIFF
--- a/.ci_support/linux_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpimpichpython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpinompipython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.8.____cpython.yaml
@@ -15,7 +15,7 @@ libnetcdf:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.6.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.7.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpimpichpython3.8.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - mpich
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.6.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.7.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpinompipython3.8.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.8.____cpython.yaml
@@ -19,7 +19,7 @@ macos_min_version:
 mpi:
 - openmpi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/win_mpinompipython3.6.____cpython.yaml
@@ -11,7 +11,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/win_mpinompipython3.7.____cpython.yaml
@@ -11,7 +11,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/win_mpinompipython3.8.____cpython.yaml
@@ -11,7 +11,7 @@ libnetcdf:
 mpi:
 - nompi
 numpy:
-- '1.14'
+- '1.16'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.5.4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -69,9 +69,6 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - mpi4py  # [mpi != 'nompi']
     - openssh  # [mpi == 'openmpi']
-    - mkl 2020.0  # [win]
-    - intel-openmp 2020.0  # [win]
-    - libssh2 1.8.*
 
 test:
   files:


### PR DESCRIPTION
These (well mkl and openmp) conflict with those for the current Windows scipy package (on defaults), making it impossible to install this package on Windows alongside it (1.5.3 works). These aren't even dependencies of this library, but artifacts of libnetcdf/mpi/openmp.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
