### PR TITLE
Remove mpich-mpicc as dependency

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpimpichnumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpimpichnumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpimpichnumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpinompinumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpinompinumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpinompinumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/osx_64_mpimpichnumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpimpichnumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpimpichnumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.18python3.6.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.18python3.7.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.18python3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.7.____73_pypy.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/win_64_mpinompinumpy1.18python3.6.____cpython.yaml
+++ b/.ci_support/win_64_mpinompinumpy1.18python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/win_64_mpinompinumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/win_64_mpinompinumpy1.18python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/win_64_mpinompinumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/win_64_mpinompinumpy1.18python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/win_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
+++ b/.ci_support/win_64_mpinompinumpy1.19python3.7.____73_pypy.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/.ci_support/win_64_mpinompinumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_mpinompinumpy1.19python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - vs2017
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 hdf5:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.5.7" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or 'nompi' %}
@@ -57,7 +57,6 @@ requirements:
     - libnetcdf
     - libnetcdf * {{ mpi_prefix }}_*
     - {{ mpi }}  # [mpi != 'nompi']
-    - mpich-mpicc  # [mpi == 'mpich']
     - mpi4py  # [mpi != 'nompi']
   run:
     - python


### PR DESCRIPTION
This was a temporary way to ensure that we did not get the external build of mpich.  It is hopefully no longer needed.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
