### PR TITLE
Set --no-build-isolation on pip build

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "netcdf4-feedstock"
-version = "3.58.0"  # conda-smithy version used to generate this file
+version = "3.59.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/netcdf4-feedstock"
 authors = ["@conda-forge/netcdf4"]
 channels = ["conda-forge"]

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -9,5 +9,5 @@ echo netCDF4_libdir = %LIBRARY_LIB% >> %SITECFG%
 echo netCDF4_incdir = %LIBRARY_INC% >> %SITECFG%
 
 set NETCDF4_LIMITED_API=1
-"%PYTHON%" -m pip install --no-deps --ignore-installed .
+"%PYTHON%" -m pip install --no-deps --ignore-installed --no-build-isolation .
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,4 +8,4 @@ export NETCDF4_LIMITED_API=1
 export netCDF4_DIR=$PREFIX
 export HDF5_DIR=$PREFIX
 
-${PYTHON} -m pip install --no-deps --ignore-installed .
+${PYTHON} -m pip install --no-deps --ignore-installed --no-build-isolation .

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   python_min: "3.11"
   # recipe-lint failed in v0 if mpi was undefined; keep the same defaulting behavior
   mpi: ${{ mpi or "nompi" }}
-  build: 7
+  build: 8
   # prioritize nompi via build number
   build_number: ${{ build + 100 if mpi == "nompi" else build }}
   mpi_prefix: ${{ "mpi_" + mpi if mpi != "nompi" else "nompi" }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I am boggling if `--no-build-isolation` fixes the `rpath` issue denoted in #191 
@conda-forge-admin please rerender