### PR TITLE
backport fix for numpy 2.5

### DIFF
--- a/recipe/backport_1469.patch
+++ b/recipe/backport_1469.patch
@@ -1,0 +1,31 @@
+--- netcdf4-1.7.4.orig/src/netCDF4/_netCDF4.pyx	2026-01-04 23:09:45.000000000 -0300
++++ netcdf4-1.7.4/src/netCDF4/_netCDF4.pyx	2026-06-22 14:31:25.313297991 -0300
+@@ -5630,7 +5630,7 @@
+             # create a view so shape in caller is not modified (issue 90)
+             try: # if extra singleton dims, just reshape
+                 data = data.view()
+-                data.shape = tuple(datashape)
++                data = data.reshape(tuple(datashape))
+             except ValueError: # otherwise broadcast
+                 data = numpy.broadcast_to(data, datashape)
+ 
+@@ -6816,8 +6816,7 @@
+     if encoding in ['none','None','bytes']:
+         b = numpy.array(tuple(a.tobytes()),'S1')
+     elif encoding == 'ascii':
+-        b = numpy.array(tuple(a.tobytes().decode(encoding)),dtype+'1')
+-        b.shape = a.shape + (n_strlen,)
++        b = (numpy.array(tuple(a.tobytes().decode(encoding)),dtype+'1')).reshape(a.shape + (n_strlen,))
+     else:
+         if not a.ndim:
+             a = numpy.array([a])
+@@ -6852,8 +6851,7 @@
+         a = numpy.array([bs[n1:n1+slen] for n1 in range(0,len(bs),slen)],'S'+repr(slen))
+     else:
+         a = numpy.array([bs[n1:n1+slen].decode(encoding) for n1 in range(0,len(bs),slen)],'U'+repr(slen))
+-    a.shape = b.shape[:-1]
+-    return a
++    return a.reshape(b.shape[:-1])
+ 
+ class MFDataset(Dataset):
+     """

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -6,7 +6,7 @@ context:
   python_min: "3.11"
   # recipe-lint failed in v0 if mpi was undefined; keep the same defaulting behavior
   mpi: ${{ mpi or "nompi" }}
-  build: 7
+  build: 8
   # prioritize nompi via build number
   build_number: ${{ build + 100 if mpi == "nompi" else build }}
   mpi_prefix: ${{ "mpi_" + mpi if mpi != "nompi" else "nompi" }}
@@ -21,6 +21,7 @@ source:
   patches:
     - 0001-update-url-for-gfs-data.patch
     - backport_1474.patch
+    - backport_1469.patch
 
 build:
   # Windows builds are only supported for the nompi variant.


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Should help us with numpy 2.5 until a new release is out.